### PR TITLE
Support trailing whitespace in text nodes

### DIFF
--- a/lib/gendocx.js
+++ b/lib/gendocx.js
@@ -210,7 +210,7 @@ function makeDocx ( genobj, new_type, options, gen_private, type_info ) {
 					} // Endif.
 
 					if ( objs_list[i].data[j].text ) {
-						if ( objs_list[i].data[j].text[0] == ' ' ) {
+						if ( (objs_list[i].data[j].text[0] == ' ') || (objs_list[i].data[j].text[objs_list[i].data[j].text.length - 1] == ' ') ) {
 							tExtra += ' xml:space="preserve"';
 						} // Endif.
 


### PR DESCRIPTION
Previously whitespace was being preserved only when the first character
of the text node is a string. Now it'll be preserved in case of trailing
whitespace as well.